### PR TITLE
fix(backend): specify timezone for dates

### DIFF
--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -2,7 +2,14 @@ import uuid
 from datetime import datetime, timezone
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator, PlainSerializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    field_validator,
+    PlainSerializer,
+)
 from typing import Union, Annotated
 
 


### PR DESCRIPTION
Implement UTC-aware datetime serialization in Pydantic schemas to ensure dates are correctly interpreted as UTC on the frontend.

---
<a href="https://cursor.com/background-agent?bcId=bc-33a080d7-ac4c-4e8f-a4a4-6191562c7c2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-33a080d7-ac4c-4e8f-a4a4-6191562c7c2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>